### PR TITLE
Add Rasant to the Rust logger benchmark.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ fern = "0.7.1"
 # Ftlog
 ftlog = "0.2.15"
 
+# Rasant
+rasant = "0.5.5"
+
 # For benchmarking
 criterion = { version = "0.5.1", features = ["html_reports"] }
 rand = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ fern = "0.7.1"
 ftlog = "0.2.15"
 
 # Rasant
-rasant = "0.5.5"
+rasant = "0.6.0"
 
 # For benchmarking
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ All benchmarks were run on:
 - **log4rs**: A highly configurable logging framework modeled after Java's log4j and logback
 - **fern**: A simple, efficient logging implementation
 - **ftlog**: Fast, zero-allocation logging library optimized for high performance
+- **Rasant**: A lightweight, high performance and flexible Rust library for structured logging.
 
 ## Running the Demo
 

--- a/benches/combined_bench.rs
+++ b/benches/combined_bench.rs
@@ -25,6 +25,10 @@ fn benchmark_performance_comparison(c: &mut Criterion) {
     let _env_logger_metrics = setup_env_logger_bench();
     let (mut rasant_logger_bench, _rasant_metrics) = setup_rasant_bench();
 
+    // Rasant sub-logger with arguments, writing to the same sinks as rasant_logger_bench.
+    let mut rasant_args_bench = rasant_logger_bench.clone();
+    rasant::set!(rasant_args_bench, foo = "xyz", bar = 123);
+
     // --- Message Size Comparison (Benchmark Configs) ---
     let mut group = c.benchmark_group("Log Message Size Comparison (Bench Configs)");
     for size in [10, 100, 1000].iter() {
@@ -48,19 +52,11 @@ fn benchmark_performance_comparison(c: &mut Criterion) {
         });
 
         group.bench_with_input(BenchmarkId::new("rasant", size), &msg, |b, m| {
-            b.iter(|| _ = rasant::info!(rasant_logger_bench, m))
+            b.iter(|| rasant::info!(rasant_logger_bench, m))
         });
-        let mut rasant_count: usize = 0;
-        group.bench_with_input(
-            BenchmarkId::new("rasant_with_arguments", size),
-            &msg,
-            |b, m| {
-                b.iter(|| {
-                    _ = rasant::info!(rasant_logger_bench, m, size = *size, count = rasant_count);
-                    rasant_count += 1;
-                })
-            },
-        );
+        group.bench_with_input(BenchmarkId::new("rasant_with_args", size), &msg, |b, m| {
+            b.iter(|| rasant::info!(rasant_args_bench, m, size = *size))
+        });
     }
     group.finish();
 
@@ -78,15 +74,12 @@ fn benchmark_performance_comparison(c: &mut Criterion) {
     group.bench_function("env_logger", |b| b.iter(|| log::info!("{}", msg)));
 
     group.bench_function("rasant", |b| {
-        b.iter(|| _ = rasant::info!(rasant_logger_bench, msg))
+        b.iter(|| rasant::info!(rasant_logger_bench, msg))
     });
-    let mut rasant_count: usize = 0;
-    group.bench_function("rasant_with_arguments", |b| {
-        b.iter(|| {
-            _ = rasant::info!(rasant_logger_bench, msg, count = rasant_count);
-            rasant_count += 1;
-        })
+    group.bench_function("rasant_with_args", |b| {
+        b.iter(|| rasant::info!(rasant_args_bench, msg))
     });
+
     group.finish();
 }
 

--- a/benches/combined_bench.rs
+++ b/benches/combined_bench.rs
@@ -5,11 +5,13 @@ use log_benchmark::logger_setup::{
     setup_env_logger_bench,
     setup_fern_bench,
     setup_log4rs_bench,
+    setup_rasant_bench,
     // Import standard setup for slog
     setup_slog,
     setup_slog_bench,
     setup_tracing_bench,
 };
+use rasant;
 use slog;
 use tracing;
 
@@ -21,6 +23,7 @@ fn benchmark_performance_comparison(c: &mut Criterion) {
     let _log4rs_metrics = setup_log4rs_bench();
     let _tracing_metrics = setup_tracing_bench();
     let _env_logger_metrics = setup_env_logger_bench();
+    let (mut rasant_logger_bench, _rasant_metrics) = setup_rasant_bench();
 
     // --- Message Size Comparison (Benchmark Configs) ---
     let mut group = c.benchmark_group("Log Message Size Comparison (Bench Configs)");
@@ -43,6 +46,21 @@ fn benchmark_performance_comparison(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("env_logger", size), &msg, |b, m| {
             b.iter(|| log::info!("{}", m))
         });
+
+        group.bench_with_input(BenchmarkId::new("rasant", size), &msg, |b, m| {
+            b.iter(|| _ = rasant::info!(rasant_logger_bench, m))
+        });
+        let mut rasant_count: usize = 0;
+        group.bench_with_input(
+            BenchmarkId::new("rasant_with_arguments", size),
+            &msg,
+            |b, m| {
+                b.iter(|| {
+                    _ = rasant::info!(rasant_logger_bench, m, size = *size, count = rasant_count);
+                    rasant_count += 1;
+                })
+            },
+        );
     }
     group.finish();
 
@@ -58,6 +76,17 @@ fn benchmark_performance_comparison(c: &mut Criterion) {
     group.bench_function("log4rs", |b| b.iter(|| log::info!("{}", msg)));
     group.bench_function("tracing", |b| b.iter(|| tracing::info!("{}", msg)));
     group.bench_function("env_logger", |b| b.iter(|| log::info!("{}", msg)));
+
+    group.bench_function("rasant", |b| {
+        b.iter(|| _ = rasant::info!(rasant_logger_bench, msg))
+    });
+    let mut rasant_count: usize = 0;
+    group.bench_function("rasant_with_arguments", |b| {
+        b.iter(|| {
+            _ = rasant::info!(rasant_logger_bench, msg, count = rasant_count);
+            rasant_count += 1;
+        })
+    });
     group.finish();
 }
 

--- a/src/logger_setup/benchmark_setups.rs
+++ b/src/logger_setup/benchmark_setups.rs
@@ -11,6 +11,7 @@ use log4rs::{
     encode::Encode,
     init_config,
 };
+use rasant;
 use slog::{o, Drain, Logger};
 use slog_term::{FullFormat, PlainSyncDecorator};
 use std::io::Write;
@@ -147,4 +148,27 @@ pub fn setup_env_logger_bench() -> Arc<MessageStats> {
         .try_init()
         .ok();
     Arc::clone(&stats)
+}
+
+// -- Rasant --
+pub fn setup_rasant_bench() -> (rasant::Logger, Arc<MessageStats>) {
+    let stats = Arc::new(MessageStats::new());
+    let writer = CountingWriter::new(Arc::clone(&stats));
+
+    let mut log = rasant::Logger::new();
+    log.add_sink(rasant::sink::io::IO::new(rasant::sink::io::IOConfig {
+        out: Some(writer),
+        name: "benchmark sink".into(),
+        formatter_cfg: rasant::FormatterConfig {
+            // A compact string: `<time> [INF] some log message key_1=value_1 key2=value_2`
+            format: rasant::OutputFormat::Compact,
+            // Compact datetime with milliseconds, in UTC: `2026-03-02 13:22:15.488`
+            time_format: rasant::TimeFormat::UtcMillisDateTime,
+            ..rasant::FormatterConfig::default()
+        },
+        ..rasant::sink::io::IOConfig::default()
+    }));
+    log.set_level(rasant::Level::Info);
+
+    (log, Arc::clone(&stats))
 }

--- a/src/logger_setup/mod.rs
+++ b/src/logger_setup/mod.rs
@@ -16,6 +16,6 @@ pub use standard_setups::{
 
 // Benchmark setup functions
 pub use benchmark_setups::{
-    setup_env_logger_bench, setup_fern_bench, setup_log4rs_bench, setup_slog_bench,
-    setup_tracing_bench,
+    setup_env_logger_bench, setup_fern_bench, setup_log4rs_bench, setup_rasant_bench,
+    setup_slog_bench, setup_tracing_bench,
 };

--- a/src/logger_setup/standard_setups.rs
+++ b/src/logger_setup/standard_setups.rs
@@ -1,6 +1,7 @@
 // src/logger_setup/standard_setups.rs
 use chrono::Local;
 use log::LevelFilter;
+use rasant;
 use slog::{o, Drain, Logger};
 use std::io::Write;
 
@@ -91,4 +92,13 @@ pub fn setup_slog() -> Logger {
 pub fn setup_tracing() {
     use tracing_subscriber::fmt;
     fmt::init();
+}
+
+// Set up Rasant for normal usage
+pub fn setup_rasant() -> rasant::Logger {
+    let mut log = rasant::Logger::new();
+    log.add_sink(rasant::sink::stdout::default())
+        .set_level(rasant::Level::Info);
+
+    log
 }


### PR DESCRIPTION
Shamelessly plugging in my structured logging library for Rust 👉👈:  https://crates.io/crates/rasant

Rasant is work-in-progress, but well on its way to v1.0.0 and already comparing **very** favorably
to all other loggers in the benchmark.